### PR TITLE
error in eega_tRejCorrCh and eega_tRejMaxChange

### DIFF
--- a/scripts/artifacts/detect/eega_tRejCorrCh.m
+++ b/scripts/artifacts/detect/eega_tRejCorrCh.m
@@ -98,7 +98,7 @@ for ep = 1:nEp
         corrs(logical(eye(size(corrs,1)))) = NaN;
         % compute the average correlation for the top channels
         ptop = prctile(corrs,100-P.topcorrch,1);
-        corrs(corrs<=repmat(ptop,[size(corrs,1) 1])) = NaN;
+        corrs(corrs<repmat(ptop,[size(corrs,1) 1])) = NaN;
         avgcorrs = nanmean(corrs);
         % store the data
         CC(:,itw,ep) = avgcorrs;

--- a/scripts/artifacts/detect/eega_tRejMaxChange.m
+++ b/scripts/artifacts/detect/eega_tRejMaxChange.m
@@ -113,7 +113,7 @@ for j=1:nR
                 dd = dd(:);
                 perc = prctile(dd,[25 50 75]);
                 IQ   = perc(3)-perc(1);  
-                t_u_el  = perc + P.thresh(j)*IQ;
+                t_u_el  = perc(3) + P.thresh(j)*IQ;
                
                 Ru(el,:,:) = Ru(el,:,:) | change(el,:,:)>t_u_el;
                 T(el,j) = t_u_el;


### PR DESCRIPTION
- solves the error in relative threshold computation in eega_tRejMaxChange
- in eega_tRejCorrCh  changes the top correlations from > than top to >=than top